### PR TITLE
fix : cicd 중 발생한 husky 와 node 버전 불일치 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Alogrithm Front CI/CD
+name: NFE1-1-8-MOODI
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Alogrithm Front CI/CD
 on:
   push:
     branches:
-      - main
+      - 8-fix-cicd-중-발생한-husky-와-node-버전-불일치-해결
 
 jobs:
   deploy:
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.0.0'
+          node-version: '20.18.0'
 
       - name: Install dependencies with Yarn
         uses: actions/cache@v3


### PR DESCRIPTION
# 🚀요약
- husky node vesion 버전 불일치 해결 

# 📸사진 (구현 캡처)

# 📝작업 내용

- [x] 노드 버전을 20.0.0 -> 20.9.0으로 업그레이드

# 🎸기타 

close #8 
