### PR TITLE
feat : 공개/비공개 버튼 컴포넌트 추가

### DIFF
--- a/public/private.svg
+++ b/public/private.svg
@@ -1,0 +1,4 @@
+<svg width="14" height="18" viewBox="0 0 14 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect y="7" width="14" height="11" rx="2" fill="black"/>
+<path d="M3.03312 8C2.84422 5.66667 3.37313 1 6.99996 1C10.6268 1 11.1558 5.66667 10.9669 8" stroke="black" stroke-width="2"/>
+</svg>

--- a/public/public.svg
+++ b/public/public.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="6" y="7" width="14" height="11" rx="2" fill="black"/>
+<path d="M1.03312 8C0.844218 5.66667 1.37313 1 4.99996 1C8.62679 1 9.15576 5.66667 8.9669 8" stroke="black" stroke-width="2"/>
+</svg>

--- a/src/feature/diary-wirte/model/type.tsx
+++ b/src/feature/diary-wirte/model/type.tsx
@@ -1,0 +1,5 @@
+export interface VisibilityButtonProps {
+    isPublic: boolean;
+    isActive: boolean;
+    onClick: () => void;
+}

--- a/src/feature/diary-wirte/ui/VisibilityButton.stories.tsx
+++ b/src/feature/diary-wirte/ui/VisibilityButton.stories.tsx
@@ -1,0 +1,28 @@
+// visibility-button.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import VisibilityButton from './VisibilityButton';
+
+const meta: Meta<typeof VisibilityButton> = {
+    title: 'Features/DiaryVisibility/VisibilityButton',
+    component: VisibilityButton,
+    tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof VisibilityButton>;
+
+export const Public: Story = {
+    args: {
+        isPublic: true,
+        isActive: true,
+        onClick: () => console.log('공개 버튼 클릭'),
+    },
+};
+
+export const Private: Story = {
+    args: {
+        isPublic: false,
+        isActive: false,
+        onClick: () => console.log('비공개 버튼 클릭'),
+    },
+};

--- a/src/feature/diary-wirte/ui/VisibilityButton.styled.tsx
+++ b/src/feature/diary-wirte/ui/VisibilityButton.styled.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+interface ButtonProps {
+    isActive?: boolean;
+}
+
+export const Container = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+`;
+
+export const StyledButton = styled.button<ButtonProps>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 70px;
+    height: 40px;
+    border-radius: 14px;
+    transition: all 0.2s ease;
+    background-color: ${(props) => (props.isActive ? '#FFF4F1' : '#ffffff')};
+    border: 1px solid ${(props) => (props.isActive ? '#FF480E' : 'rgba(0, 0, 0, 0.1)')};
+    &:hover {
+        cursor: pointer;
+        background-color: ${(props) => (props.isActive ? '#FFF4F1' : 'rgba(0, 0, 0, 0.1)')};
+    }
+`;
+
+export const StyledImg = styled.img`
+    height: 17px;
+`;

--- a/src/feature/diary-wirte/ui/VisibilityButton.tsx
+++ b/src/feature/diary-wirte/ui/VisibilityButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Container, StyledButton, StyledImg } from './VisibilityButton.styled';
+import { VisibilityButtonProps } from '../model/type';
+
+const VisibilityButton = ({ isPublic, isActive, onClick }: VisibilityButtonProps) => {
+    return (
+        <Container>
+            <StyledButton isActive={isActive} onClick={onClick} type="button" aria-label={isPublic ? '공개' : '비공개'}>
+                <StyledImg src={isPublic ? '/public.svg' : '/private.svg'} alt={isPublic ? '공개' : '비공개'} />
+            </StyledButton>
+        </Container>
+    );
+};
+
+export default VisibilityButton;


### PR DESCRIPTION
# 🚀요약
일기 작성 페이지의 공개/비공개 버튼 컴포넌트 추가

# 📸사진 (구현 캡처)

# 📝작업 내용

- 공개/비공개 버튼 컴포넌트 생성
- 스타일링

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #18 
