### PR TITLE
fix : 공유 컴포넌트 타입 분리 및 오류 수정

### DIFF
--- a/src/shared/ui/Button/Button.styled.tsx
+++ b/src/shared/ui/Button/Button.styled.tsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
-import { ButtonProps } from './Button';
+import { ButtonProps } from './Button.types';
 
-export const StyledButton = styled.button<ButtonProps>`
+export const StyledButton = styled.button.withConfig({
+    shouldForwardProp: (prop) => !['isActive', 'hasBorder'].includes(prop)
+})<ButtonProps>`
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/shared/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/Button.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
 import { StyledButton } from './Button.styled';
-
-export interface ButtonProps {
-    children: React.ReactNode;
-    fontSize: string;
-    isActive: boolean;
-    hasBorder: boolean;
-    height: string;
-    width: string;
-    onClick: () => void;
-}
+import { ButtonProps } from './Button.types';
 
 const Button = ({
     children,

--- a/src/shared/ui/Button/Button.types.ts
+++ b/src/shared/ui/Button/Button.types.ts
@@ -1,0 +1,9 @@
+export interface ButtonProps {
+    children: React.ReactNode;
+    fontSize: string;
+    isActive: boolean;
+    hasBorder: boolean;
+    height: string;
+    width: string;
+    onClick: () => void;
+}


### PR DESCRIPTION
# 🚀요약
공유 컴포넌트 버튼의 타입을 분리했습니다.
특정 prop이 DOM에 직접 전달돼서 발생하는 생기는 오류를 수정했습니다.
# 📸사진 (구현 캡처)

# 📝작업 내용

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #46
