### PR TITLE
feat : 랜딩페이지 부분 완성

### DIFF
--- a/src/pages/LandingPage/index.ts
+++ b/src/pages/LandingPage/index.ts
@@ -1,0 +1,1 @@
+export { LandingPage } from './ui/Page/Page';

--- a/src/pages/LandingPage/ui/LandingTitle/LandingTitle.stories.ts
+++ b/src/pages/LandingPage/ui/LandingTitle/LandingTitle.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LandingTitle from './LandingTitle';
+
+const meta: Meta<typeof LandingTitle> = {
+    title: 'Page/LandingPage/LandingTitle',
+    component: LandingTitle,
+    tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof LandingTitle>;
+
+export const Default: Story = {
+    args: {
+        title: `Life's playlist, \nYour Story`
+    }
+};

--- a/src/pages/LandingPage/ui/LandingTitle/LandingTitle.styled.ts
+++ b/src/pages/LandingPage/ui/LandingTitle/LandingTitle.styled.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const Title = styled.h1`
+    font-size: 128px;
+    font-weight: bold;
+    color: #000000;
+    text-align: start;
+    line-height: 130px;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    white-space: pre-wrap;
+    font-family: 'Pretendard', sans-serif;
+`;

--- a/src/pages/LandingPage/ui/LandingTitle/LandingTitle.tsx
+++ b/src/pages/LandingPage/ui/LandingTitle/LandingTitle.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Title } from './LandingTitle.styled';
+
+interface LandingTitleProps {
+    title: string;
+}
+
+const LandingTitle = ({ title }: LandingTitleProps) => {
+    return <Title>{title}</Title>;
+};
+
+export default LandingTitle;

--- a/src/pages/LandingPage/ui/Page/Page.stories.ts
+++ b/src/pages/LandingPage/ui/Page/Page.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LandingPage } from './Page';
+
+const meta: Meta<typeof LandingPage> = {
+    title: 'Page/LandingPage/Page',
+    component: LandingPage,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: '미완성된 랜딩페이지 입니다.'
+            }
+        }
+    }
+};
+
+export default meta;
+type Story = StoryObj<typeof LandingPage>;
+
+export const Default: Story = {
+    args: {}
+};

--- a/src/pages/LandingPage/ui/Page/Page.styled.ts
+++ b/src/pages/LandingPage/ui/Page/Page.styled.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const PageContainer = styled.div`
+    max-width: 960px; // 원하는 최대 너비
+    width: 100%;
+    background-color: #ffffff;
+`;
+export const LandingContainer = styled.div`
+    margin-bottom: 30px;
+`;
+export const SubTitleContainer = styled.div`
+    margin-bottom: 100px;
+`;

--- a/src/pages/LandingPage/ui/Page/Page.tsx
+++ b/src/pages/LandingPage/ui/Page/Page.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+    PageContainer,
+    LandingContainer,
+    SubTitleContainer
+} from './Page.styled';
+import LandingTitle from '../LandingTitle/LandingTitle';
+import SubTitle from '../SubTitle/SubTitle';
+import Button from '../../../../shared/ui/Button/Button';
+import Header from '../../../../widgets/header/ui/Header';
+
+export const LandingPage = () => {
+    const handleLoginClick = () => {
+        // eslint-disable-next-line no-console
+        console.log('click login button!');
+    };
+
+    return (
+        <PageContainer>
+            <Header />
+            <LandingContainer>
+                <LandingTitle title={`Life's Playlist, \nYour Story`} />
+            </LandingContainer>
+            <SubTitleContainer>
+                <SubTitle subTitle="무디에서 감정을 담은 일기를 작성해보세요." />
+            </SubTitleContainer>
+            <Button
+                height="79px"
+                width="247px"
+                fontSize="20px"
+                borderradius="15px"
+                onClick={handleLoginClick}
+            >
+                로그인 하기
+            </Button>
+        </PageContainer>
+    );
+};

--- a/src/pages/LandingPage/ui/SubTitle/SubTitle.stories.ts
+++ b/src/pages/LandingPage/ui/SubTitle/SubTitle.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SubTitle from './SubTitle';
+
+const meta: Meta<typeof SubTitle> = {
+    title: 'Page/LandingPage/SubTitle',
+    component: SubTitle,
+    tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof SubTitle>;
+
+export const Default: Story = {
+    args: {
+        subTitle: `무디에서 감정을 담은 일기를 작성해보세요.`
+    }
+};

--- a/src/pages/LandingPage/ui/SubTitle/SubTitle.styled.ts
+++ b/src/pages/LandingPage/ui/SubTitle/SubTitle.styled.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const Title = styled.h1`
+    font-size: 24px;
+    font-weight: bold;
+    color: #000000;
+    text-align: start;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    white-space: pre-wrap;
+    font-family: 'Pretendard', sans-serif;
+`;

--- a/src/pages/LandingPage/ui/SubTitle/SubTitle.tsx
+++ b/src/pages/LandingPage/ui/SubTitle/SubTitle.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Title } from './SubTitle.styled';
+
+interface SubTitleProps {
+    subTitle: string;
+}
+
+const SubTitle = ({ subTitle }: SubTitleProps) => {
+    return <Title>{subTitle}</Title>;
+};
+
+export default SubTitle;


### PR DESCRIPTION
# 🚀요약
랜딩페이지 부분 완성
# 📸사진 (구현 캡처)
![2024-10-29 15 28 51](https://github.com/user-attachments/assets/22b0d8fd-b0cd-41ed-8375-f67f5885be47)
# 📝작업 내용

-   랜딩페이지 랜딩타이틀과 서브타이틀, 로그인 하기 버튼

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)
- 아직 App 부분에서 스타일 지정이나 라우팅은 하지 못했습니다.
close #48
