### PR TITLE
feat : 일기 리스트 아이템 컴포넌트 UI 개발

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,7 +62,8 @@ export default [
                 }
             ],
             'import/prefer-default-export': 'off',
-            'import/order': 'off'
+            'import/order': 'off',
+            'react/prop-types': 'off'
         },
         overrides: [
             {

--- a/src/features/diary-list-item/diary-list-item-type/DiaryListItemType.ts
+++ b/src/features/diary-list-item/diary-list-item-type/DiaryListItemType.ts
@@ -1,0 +1,26 @@
+export interface ReactionType {
+    id: number;
+    type: string;
+    user_email: string;
+    created_at: string;
+}
+
+export interface SubEmotionType {
+    sub_mood: string;
+    intensity: number;
+}
+
+export interface DiaryListItemType {
+    id: number;
+    title: string;
+    content: string;
+    is_public: number;
+    music_url: string;
+    mood: string;
+    emotion: string;
+    sub_emotion: SubEmotionType | string; // string type needed if it's stored as JSON string
+    created_date: string;
+    updated_date: string;
+    author_email: string;
+    reactions: ReactionType[];
+}

--- a/src/features/diary-list-item/diary-list-item-ui/content-box/ContentBox.tsx
+++ b/src/features/diary-list-item/diary-list-item-ui/content-box/ContentBox.tsx
@@ -1,0 +1,37 @@
+import {
+    Wrapper,
+    Top,
+    Title,
+    Name,
+    Bottom,
+    Paragraph,
+    Time,
+    Reaction,
+    Emotion
+} from './ContentBoxCss';
+import { getEmoticonPath } from '@/shared/model/getEmotionPath';
+
+interface ContentBoxProps {
+    title: string;
+    content: string;
+    emotion: string;
+}
+
+const ContentBox: React.FC<ContentBoxProps> = ({ title, content, emotion }) => {
+    return (
+        <Wrapper>
+            <Top>
+                <Title>{title}</Title>
+                <Name>김민준</Name>
+            </Top>
+            <Paragraph>{content}</Paragraph>
+            <Bottom>
+                <Time>30분전</Time>
+                <Reaction />
+            </Bottom>
+            <Emotion imgPath={getEmoticonPath(emotion)} />
+        </Wrapper>
+    );
+};
+
+export default ContentBox;

--- a/src/features/diary-list-item/diary-list-item-ui/content-box/ContentBoxCss.ts
+++ b/src/features/diary-list-item/diary-list-item-ui/content-box/ContentBoxCss.ts
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+    padding-top: 0.5rem;
+    flex: 1;
+`;
+
+export const Paragraph = styled.p`
+    max-height: 30px;
+    margin: 0.6rem 0;
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.6);
+    line-height: 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+export const Top = styled.div`
+    display: flex;
+    gap: 1rem;
+`;
+
+export const Title = styled.p`
+    font-size: 1rem;
+    color: black;
+    font-weight: 500;
+`;
+
+export const Name = styled.p`
+    font-size: 14px;
+    color: #414141;
+`;
+
+export const Bottom = styled.div`
+    height: 30px;
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+`;
+
+export const Time = styled.div`
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.4);
+`;
+
+export const Reaction = styled.div`
+    width: 200px;
+    height: 30px;
+    border: 1px solid black;
+`;
+
+export const Emotion = styled.div<{ imgPath: string | null }>`
+    width: 40px;
+    height: 60px;
+    position: absolute;
+    top: 10px;
+    right: 1rem;
+    background-image: url(${(props) => props.imgPath});
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+`;

--- a/src/features/diary-list-item/diary-list-item-ui/image-box/ImageBox.tsx
+++ b/src/features/diary-list-item/diary-list-item-ui/image-box/ImageBox.tsx
@@ -1,0 +1,7 @@
+import { Box } from './ImageBoxCss';
+
+const ImageBox = () => {
+    return <Box />;
+};
+
+export default ImageBox;

--- a/src/features/diary-list-item/diary-list-item-ui/image-box/ImageBoxCss.ts
+++ b/src/features/diary-list-item/diary-list-item-ui/image-box/ImageBoxCss.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const Box = styled.div`
+    width: 135px;
+    height: 115px;
+    border: 1px solid black;
+    border-radius: 15px;
+`;

--- a/src/features/diary-list-item/diary-list-item-ui/index.tsx
+++ b/src/features/diary-list-item/diary-list-item-ui/index.tsx
@@ -1,0 +1,23 @@
+import { Wrapper } from './indexCss';
+import ImageBox from './image-box/ImageBox';
+import ContentBox from './content-box/ContentBox';
+import { DiaryListItemType } from '../diary-list-item-type/DiaryListItemType';
+
+interface DiaryListItemProps {
+    data: DiaryListItemType;
+}
+
+const DiaryListItemUi: React.FC<DiaryListItemProps> = ({ data }) => {
+    return (
+        <Wrapper>
+            <ImageBox />
+            <ContentBox
+                title={data.title}
+                content={data.content}
+                emotion={data.emotion}
+            />
+        </Wrapper>
+    );
+};
+
+export default DiaryListItemUi;

--- a/src/features/diary-list-item/diary-list-item-ui/indexCss.ts
+++ b/src/features/diary-list-item/diary-list-item-ui/indexCss.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+    max-width: 960px;
+    width: 100%;
+    height: 150px;
+    border-radius: 30px;
+    background-color: #f8f8f8;
+    padding: 0 5rem 0 1.5rem;
+    display: flex;
+    gap: 1.4rem;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+`;

--- a/src/features/diary-list-item/index.tsx
+++ b/src/features/diary-list-item/index.tsx
@@ -1,0 +1,12 @@
+import DiaryListItemUi from './diary-list-item-ui/index';
+import { DiaryListItemType } from './diary-list-item-type/DiaryListItemType';
+
+interface DiaryListItemProps {
+    data: DiaryListItemType;
+}
+
+const DiaryListItem: React.FC<DiaryListItemProps> = ({ data }) => {
+    return <DiaryListItemUi data={data} />;
+};
+
+export default DiaryListItem;

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,0 +1,30 @@
+import DiaryListItem from '@/features/diary-list-item';
+
+const item = {
+    id: 31,
+    title: '오늘 나의 일기',
+    content:
+        '신나는 제주도 여행 1일차다. 정말 신난다. 신나는 제주도 여행 신나는 제주도 여행 1일차다. 정말 신난다. 신나는 제주도 여행 신나는 제주도 여행 1일차다. 정말 신난다. 신나는 제주도 여행 신나는 제주도 여행 1일차다. 정말 신난다. 신나는 제주도 여행 신나는 제주도 여행 1일차다. 정말 신난다. 신나는 제주도 여행 신나는 제주도 여행 1일차다. 정말 신난다. 신나는 제주도 여행',
+    is_public: 1,
+    music_url: 'http://example.com/music.mp3',
+    mood: '매우 나쁨',
+    emotion: '자신 있어요',
+    sub_emotion: '{"sub_mood": "행복", "intensity": 8}',
+    created_date: '2024-10-27T07:12:33.000Z',
+    updated_date: '2024-10-28T03:39:36.000Z',
+    author_email: 'alice.wonder@example.com',
+    reactions: [
+        {
+            id: 34,
+            type: '화나요',
+            user_email: 'alice.wonder@example.com',
+            created_at: '2024-10-24T03:58:35.000Z'
+        }
+    ]
+};
+
+const MainPage = () => {
+    return <DiaryListItem data={item} />;
+};
+
+export default MainPage;

--- a/src/shared/model/getEmotionPath.ts
+++ b/src/shared/model/getEmotionPath.ts
@@ -1,0 +1,32 @@
+export const getEmoticonPath = (emotion: string) => {
+    const emotionMap: Record<string, string> = {
+        기뻐요: 'emoji_happy',
+        '자신 있어요': 'emoji_confident',
+        감사해요: 'emoji_grateful',
+        편안해요: 'emoji_comfortable',
+        신이나요: 'emoji_excited',
+        즐거워요: 'emoji_fun',
+        만족스러워요: 'emoji_satisfied',
+        사랑스러워요: 'emoji_lovely',
+        모르겠어요: 'emoji_not_sure',
+        부끄러워요: 'emoji_embarrassed',
+        놀라워요: 'emoji_surprised',
+        '아무생각이 없어요': 'emoji_blank',
+        슬퍼요: 'emoji_sad',
+        우울해요: 'emoji_depressed',
+        실망스러워요: 'emoji_disappointed',
+        후회돼요: 'emoji_regret',
+        짜증나요: 'emoji_annoyed',
+        화나요: 'emoji_angry',
+        외로워요: 'emoji_lonley',
+        충격받았어요: 'emoji_shocked',
+        곤란해요: 'emoji_awkward'
+    };
+
+    const svgName = emotionMap[emotion];
+    if (!svgName) {
+        return null; // 매칭되는 감정이 없을 경우
+    }
+
+    return `emoji/${svgName}.svg`;
+};


### PR DESCRIPTION
# 🚀요약
일기 리스트 아이템 컴포넌트 UI개발 1차

# 📸사진 (구현 캡처)
![제목 없음](https://github.com/user-attachments/assets/e525dfe3-d453-4ad5-b89c-38a8f3bda058)

# 📝작업 내용
1. 일기 리스트 아이템 컴포넌트 UI 개발
2. 타이틀, 내용, 감정키워드까지 받아오기 작업 완료
3. 이름, 썸네일, 노래제목 은 api업데이트 후에 추가 작업 예정
4. 리액션 부분은 리액션 컴포넌트 개발 이후에 추가 작업 예정
5. shared의 model에 getEmoticonPath함수 추가해놓음. (emotion을 한국어 string상태의 인자로 받아서 path를 반환)
-   [ ]
-   [ ]

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)
백엔드 추가작업과 리액션 작업이 완료되면 MainPage작업과 함께 개발 예정
eslint의 rules에 'react/prop-types': 'off' 추가함

close #66 
