### PR TITLE
fix : EmotionButtonGroup 타입 오류 수정

### DIFF
--- a/src/features/diary-write/emotion/ui/EmotionButtonGroup.tsx
+++ b/src/features/diary-write/emotion/ui/EmotionButtonGroup.tsx
@@ -77,7 +77,9 @@ export const EmotionButtonGroup: React.FC<EmotionButtonGroupProps> = ({
                 onSelectionChange={handleClickEmotion}
                 maxSelections={1}
                 isPrimary
-                initialSelectedEmotions={[keywords[activeButton]]}
+                initialSelectedEmotions={
+                    keywords[activeButton] ? [keywords[activeButton]] : []
+                }
             />
         </EmotionButtonContainer>
     );


### PR DESCRIPTION
# 🚀요약

# 📸사진 (구현 캡처)

# 📝작업 내용

EmotionButtonGroup에서 keywords[activeButton]이 null일 수 있어서 발생하는 오류 수정

## 🔍백엔드 전달 사항

# 🎸기타 (연관 이슈)

close #이슈번호
