### PR TITLE
feat : gpt api 연결

### DIFF
--- a/src/entities/music/api/fetchGptRecommend.ts
+++ b/src/entities/music/api/fetchGptRecommend.ts
@@ -1,0 +1,25 @@
+import defaultApi from '@/shared/api/api';
+import { gptAnswerType, gptQueryParamsType } from '../model/type';
+
+const api = defaultApi();
+
+/**
+ * 작성한 일기를 기반으로 gpt api를 이용해 추천된 노래를 반환
+ * @param params 일기 내용과 선택한 감정들
+ * @returns 음악 리스트 10개
+ */
+export const fetchGptRecommend = async (
+    params: gptQueryParamsType
+): Promise<gptAnswerType> => {
+    try {
+        const response = await api.post('/prediction', params, {
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+        return response.data;
+    } catch (error) {
+        console.log('GPT 응답 가져오기 실패');
+        throw error;
+    }
+};

--- a/src/entities/music/api/fetchMusicList.ts
+++ b/src/entities/music/api/fetchMusicList.ts
@@ -1,8 +1,7 @@
 import React from 'react';
 import axios from 'axios';
-import { MusicItem, YouTubeResponse, SpotifyResponse } from '../model/type';
+import { YouTubeResponse, SpotifyResponse } from '../model/type';
 import defaultApi from '../../../shared/api/api';
-import { useQuery } from '@tanstack/react-query';
 
 /**
  * 스포티파이 토큰 발급

--- a/src/entities/music/model/type.ts
+++ b/src/entities/music/model/type.ts
@@ -38,3 +38,13 @@ export interface YouTubeResponse {
         videoId: string;
     };
 }
+
+export interface gptQueryParamsType {
+    mood?: string;
+    emotion?: string;
+    subemotion?: string[];
+    title?: string;
+    content?: string;
+}
+
+export type gptAnswerType = string[];

--- a/src/pages/DiaryWritePage/index.ts
+++ b/src/pages/DiaryWritePage/index.ts
@@ -1,0 +1,1 @@
+export { DiaryWritePage } from './ui/DiaryWritePage';

--- a/src/pages/DiaryWritePage/ui/DiaryWritePage.styled.tsx
+++ b/src/pages/DiaryWritePage/ui/DiaryWritePage.styled.tsx
@@ -1,9 +1,13 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-    width: 100%;
+    display: flex;
+    flex-direction: column;
+`;
+
+export const Section = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1rem;
+    padding: 0 200px 0 200px;
 `;

--- a/src/pages/DiaryWritePage/ui/DiaryWritePage.tsx
+++ b/src/pages/DiaryWritePage/ui/DiaryWritePage.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { SelectMusicContainer } from '@/widgets/select-music/ui/SelectMusicContainer';
+import Header from '@/widgets/header/ui/Header';
+import { Container, Section } from './DiaryWritePage.styled';
+import { SelectEmotionContainer } from '@/widgets/select-emotion';
+import { WriteDiaryContainer } from '@/widgets/write-diary';
+import { fetchGptRecommend } from '@/entities/music/api/fetchGptRecommend';
+import { gptAnswerType, gptQueryParamsType } from '@/entities/music/model/type';
+
+export const DiaryWritePage = () => {
+    // 테스트 데이터
+    const testdiary: gptQueryParamsType = {
+        mood: '매우 나쁨',
+        emotion: '슬픔',
+        subemotion: ['슬픔'],
+        title: '우울해',
+        content: '너무 우울해서 빵샀어'
+    };
+    // const testdata = '뉴진스 supernatural';
+
+    const [diaryData, setDiaryData] = useState();
+    const [emotionData, setEmotionData] = useState();
+
+    const [gptRecommendMusicList, setGptRecommendMusicList] =
+        useState<gptAnswerType>([]);
+
+    // // 일기 데이터가 넘어오면 셋팅
+    // const handleDiarySubmit = (diaryData) => {
+    //     setDiaryData(diaryData);
+    // };
+
+    // // 감정 데이터가 넘어오면 셋팅
+    // const handleEmotionSelect = (emotionData) => {
+    //     setEmotionData(emotionData);
+    // };
+
+    // const checkAndFetchRecommendations = async () => {
+    //     const recommendations = await fetchGptRecommend(testdiary);
+    //     setGptRecommendMusicList(recommendations);
+    // };
+
+    const testFunction = async () => {
+        const recommendations = await fetchGptRecommend(testdiary);
+        setGptRecommendMusicList(recommendations);
+    };
+
+    return (
+        <Container>
+            <Header />
+            <Section>
+                {/* <WriteDiaryContainer onDiarySubmit={handleDiarySubmit} />
+                <SelectEmotionContainer onEmotionSelect={handleEmotionSelect} /> */}
+                <button type="button" onClick={() => testFunction()}>
+                    테스트 버튼
+                </button>
+                <SelectMusicContainer
+                    gptRecommendMusicList={gptRecommendMusicList}
+                />
+            </Section>
+        </Container>
+    );
+};

--- a/src/widgets/select-emotion/index.ts
+++ b/src/widgets/select-emotion/index.ts
@@ -1,0 +1,1 @@
+export { SelectEmotionContainer } from './ui/SelectEmotionContainer';

--- a/src/widgets/select-emotion/model/type.ts
+++ b/src/widgets/select-emotion/model/type.ts
@@ -1,0 +1,3 @@
+export interface SelectEmotionContainerProps {
+    onEmotionSelect: () => void;
+}

--- a/src/widgets/select-emotion/ui/SelectEmotionContainer.styled.tsx
+++ b/src/widgets/select-emotion/ui/SelectEmotionContainer.styled.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+    display: flex;
+    width: 100%;
+
+    // 임시 스타일
+    height: 200px;
+    border-radius: 10px;
+    background-color: #eeeeee;
+`;

--- a/src/widgets/select-emotion/ui/SelectEmotionContainer.tsx
+++ b/src/widgets/select-emotion/ui/SelectEmotionContainer.tsx
@@ -1,0 +1,8 @@
+import { SelectEmotionContainerProps } from '../model/type';
+import { Container } from './SelectEmotionContainer.styled';
+
+export const SelectEmotionContainer = ({
+    onEmotionSelect
+}: SelectEmotionContainerProps) => {
+    return <Container>감정 선택 위젯</Container>;
+};

--- a/src/widgets/select-music/model/type.ts
+++ b/src/widgets/select-music/model/type.ts
@@ -1,0 +1,3 @@
+export interface SelectMusicContainerProps {
+    gptRecommendMusicList: string[];
+}

--- a/src/widgets/select-music/ui/SelectMusicContainer.stories.tsx
+++ b/src/widgets/select-music/ui/SelectMusicContainer.stories.tsx
@@ -28,7 +28,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// 기본 스토리
-export const Default: Story = {
-   args: {}
-};
+// // 기본 스토리
+// export const Default: Story = {
+//    args: {}
+// };

--- a/src/widgets/select-music/ui/SelectMusicContainer.tsx
+++ b/src/widgets/select-music/ui/SelectMusicContainer.tsx
@@ -10,30 +10,29 @@ import {
     SEARCH_TYPE
 } from '@/features/diary-write/search-mode-selector/model/type';
 import { useMusicSearch } from '@/entities/music';
-
-// GPT 테스트용 리스트입니다
-// 실제로는 API가 내려준 리스트가 들어옵니다.
-const testdata = '뉴진스 supernatural';
+import { SelectMusicContainerProps } from '../model/type';
 
 // TODO - 로딩스피너 추가
-export const SelectMusicContainer = () => {
+export const SelectMusicContainer = ({
+    gptRecommendMusicList
+}: SelectMusicContainerProps) => {
     const [selectedType, setSelectedType] = useState<SearchType>(
         SEARCH_TYPE.GPT
-    ); // 현재 선택된 리스트 타입
-    const [searchKeyword, setSearchKeyword] = useState<string>(''); // 현재 검색 키워드
+    );
+    const [searchKeyword, setSearchKeyword] = useState<string>('');
     const userMusic = useMusicSearch(
         selectedType === SEARCH_TYPE.USER ? searchKeyword : ''
     );
     const gptMusic = useMusicSearch(
-        selectedType === SEARCH_TYPE.GPT ? testdata : ''
+        selectedType === SEARCH_TYPE.GPT ? gptRecommendMusicList[0] : ''
     );
 
     const userMusicList = useMemo(() => {
         return userMusic && userMusic.data ? [userMusic.data] : [];
-    }, [userMusic?.data]);
+    }, [userMusic]);
     const gptMusicList = useMemo(() => {
         return gptMusic && gptMusic.data ? [gptMusic.data] : [];
-    }, [gptMusic?.data]);
+    }, [gptMusic]);
 
     /**
      * 리스트 타입 세팅

--- a/src/widgets/write-diary/index.ts
+++ b/src/widgets/write-diary/index.ts
@@ -1,0 +1,1 @@
+export { WriteDiaryContainer } from './ui/WriteDiaryContainer';

--- a/src/widgets/write-diary/model/type.ts
+++ b/src/widgets/write-diary/model/type.ts
@@ -1,0 +1,3 @@
+export interface WriteDiaryContainerProps {
+    onDiarySubmit: () => void;
+}

--- a/src/widgets/write-diary/ui/WriteDiaryContainer.styled.tsx
+++ b/src/widgets/write-diary/ui/WriteDiaryContainer.styled.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+    display: flex;
+    width: 100%;
+
+    // 임시 스타일
+    height: 200px;
+    border-radius: 10px;
+    background-color: #eeeeee;
+`;

--- a/src/widgets/write-diary/ui/WriteDiaryContainer.tsx
+++ b/src/widgets/write-diary/ui/WriteDiaryContainer.tsx
@@ -1,0 +1,8 @@
+import { WriteDiaryContainerProps } from '../model/type';
+import { Container } from './WriteDiaryContainer.styled';
+
+export const WriteDiaryContainer = ({
+    onDiarySubmit
+}: WriteDiaryContainerProps) => {
+    return <Container>일기 작성 위젯~</Container>;
+};


### PR DESCRIPTION
# 🚀요약
일기 작성 페이지 gpt 연결

# 📸사진 (구현 캡처)
```js
    // 테스트 데이터
    const testdiary: gptQueryParamsType = {
        mood: '매우 나쁨',
        emotion: '슬픔',
        subemotion: ['슬픔'],
        title: '우울해',
        content: '너무 우울해서 빵샀어'
    };
```
![image](https://github.com/user-attachments/assets/4abde193-0095-49ef-8955-cd619769c444)


# 📝작업 내용

- 일기 작성 페이지 임시 생성
- `fetchGptRecommend.ts` 작성
- 테스트 데이터로 gpt api 구동 확인
- 기타 연관 컴포넌트 타입 수정

# 🎸기타 (연관 이슈)
* 작성 페이지에서 제출 데이터는 로컬 state로 관리합니다
* 다른 기능들은 일기 작성 페이지 위젯, 페이지 조립 끝난 다음에 진행해야 할 것 같습니다

close #83 
